### PR TITLE
Add Gemini sales playbook generation

### DIFF
--- a/app/services/sales_intents.py
+++ b/app/services/sales_intents.py
@@ -1,0 +1,29 @@
+import re
+from typing import Optional, Dict
+
+# Триггеры «как продавать»
+_PATTERNS = [
+    r"как\s+продать", r"как\s+предложить", r"что\s+говорить",
+    r"скрипт\s+продаж", r"аргумент(ы)?\s+для\s+продаж",
+    r"возражен(ие|ия|ий)", r"апс(е|э)лл|upsell|допродаж"
+]
+
+# Простейшее определение канала/формата точки
+_OUTLETS: Dict[str, str] = {
+    "тт": "budget_tt", "дискаунтер": "discount", "магазин": "retail",
+    "супермаркет": "supermarket", "бар": "bar", "ресторан": "restaurant",
+    "кафе": "cafe", "клуб": "club"
+}
+
+def detect_sales_intent(text: str) -> Optional[dict]:
+    t = (text or "").lower()
+    if not t:
+        return None
+    if not any(re.search(p, t) for p in _PATTERNS):
+        return None
+    outlet = None
+    for k, v in _OUTLETS.items():
+        if k in t:
+            outlet = v
+            break
+    return {"outlet": outlet}


### PR DESCRIPTION
## Summary
- detect sales-related queries and infer outlet type
- generate sales playbook via Gemini when intent detected
- route early AI handler to sales playbook responses

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689bc38cec988323acb10caa2cea8cad