### PR TITLE
Add AI mode menus and entry/exit handlers

### DIFF
--- a/app/keyboards/menus.py
+++ b/app/keyboards/menus.py
@@ -1,0 +1,15 @@
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton, InlineKeyboardMarkup, InlineKeyboardButton
+
+AI_ENTRY_BUTTON_TEXT = "AI эксперт 🤖"
+AI_EXIT_BUTTON_TEXT  = "Выйти из AI режима"
+
+def main_menu_kb() -> ReplyKeyboardMarkup:
+    return ReplyKeyboardMarkup(
+        keyboard=[[KeyboardButton(text=AI_ENTRY_BUTTON_TEXT)]],
+        resize_keyboard=True
+    )
+
+def ai_exit_inline_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text=AI_EXIT_BUTTON_TEXT, callback_data="ai:exit")]]
+    )

--- a/app/routers/main.py
+++ b/app/routers/main.py
@@ -1,10 +1,11 @@
 
 import json
 from aiogram import Router, F
-from aiogram.filters import CommandStart
-from aiogram.types import Message, ReplyKeyboardRemove, KeyboardButton
+from aiogram.filters import Command
+from aiogram.types import Message, KeyboardButton
 from aiogram.utils.keyboard import ReplyKeyboardBuilder
-from app.keyboards.common import main_kb, ai_entry_kb
+from app.keyboards.common import main_kb
+from app.keyboards.menus import main_menu_kb
 from app.services.stats import get_stats, format_activity
 
 ADMIN_IDS = {1294415669}
@@ -71,11 +72,10 @@ def contact_kb():
         KeyboardButton(text="Отправить номер", request_contact=True)
     ).as_markup(resize_keyboard=True)
 
-@router.message(CommandStart())
-async def cmd_start(m: Message):
+@router.message(Command("start"))
+async def start(m: Message):
     ensure_user(m.from_user)
-    await m.answer("Привет! Выбери режим:", reply_markup=main_kb(m.from_user.id in ADMIN_IDS))
-    await m.answer("Чтобы задать вопрос или найти бренд, нажмите кнопку ниже:", reply_markup=ai_entry_kb())
+    await m.answer("Главное меню", reply_markup=main_menu_kb())
 
 @router.message(F.text == "📊 Моя статистика")
 async def show_stats(m: Message):


### PR DESCRIPTION
## Summary
- Add dedicated menu keyboards with AI entry and exit buttons
- Support entering AI mode via reply button or /ai command, and exiting via inline button or /ai_off
- Show main menu keyboard on /start and when leaving AI mode

## Testing
- `python -m py_compile app/keyboards/menus.py app/routers/ai_helper.py app/routers/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc53523048323b263744da30bf32d